### PR TITLE
initial implementation of SpeakerEncoder forward function

### DIFF
--- a/tacotron2/speaker/model.py
+++ b/tacotron2/speaker/model.py
@@ -5,11 +5,49 @@ import numpy as np
 import torch
 
 class SpeakerEncoder(nn.Module):
+    """ Learn speaker representation from speech utterance of arbitrary lengths.
+    """
     def __init__(self, device, loss_device):
-        pass
+        super().__init__()
+        self.loss_device = loss_device
 
-    def forward(self, utterances, hidden_init=None):
-        pass
+        # initial lstm takes 40 channel log-mel spectrograms, projected to 256 dimensions
+        self.lstm1 = nn.LSTM(
+            input_size=40,
+            hidden_size=256,
+            num_layers=1,
+            batch_first=True,
+            dropout=0,
+            bidirectional=False,
+            proj_size=256
+        ).to(device)
+        # other two lstms
+        self.lstm2_3 = nn.LSTM(
+            input_size=256,
+            hidden_size=256,
+            num_layers=2,
+            batch_first=True,
+            dropout=0,
+            bidirectional=False,
+            proj_size=256
+        ).to(device)
+        self.linear = nn.Linear(in_features=256, out_features=256).to(device)
+        self.relu = nn.ReLU().to(device)
+        # epsilon term for numerical stability ( ie - division by 0)
+        self.epsilon = 1e-5
+
+    def forward(self, utterances, h_init=None, c_init=None):
+        # implement section 2.1 from https://arxiv.org/pdf/1806.04558.pdf
+        out, (hidden, cell) = self.lstm1(utterances, (h_init, c_init))
+        out, (hidden, cell) = self.lstm2_3(out, (hidden, cell))
+
+        # compute speaker embedding from hidden state of final layer
+        final_hidden = hidden[-1]
+        speaker_embedding = self.relu(self.linear(final_hidden))
+
+        # l2 norm of speaker embedding
+        speaker_embedding = speaker_embedding / (torch.norm(speaker_embedding, dim=1, keepdim=True) + self.epsilon)
+        return speaker_embedding
 
     def gradient_clipping():
         pass


### PR DESCRIPTION
Hey team, this is my initial implementation of the forward function for SpeakerEncoder.

I'm not too certain what the author is referring to in this part of the [paper](https://arxiv.org/pdf/1806.04558.pdf): `Input 40-channel log-mel spectrograms are passed to a network consisting of a stack of 3 LSTM layers of 768 cells, each followed by a projection to 256 dimensions.`.

My interpretation is that, out of the 3 lstm layers, the initial lstm expects an input size of 40 (40 channels = input size of 40? unsure about the input shape as it's not implemented yet) and output dim of 256, and the rest of layers are set to 256 for both input and output dims.

However, looking at @CorentinJ's [implementation](https://github.com/CorentinJ/Real-Time-Voice-Cloning/blob/0713f860a3dd41afb56e83cff84dbdf589d5e11a/encoder/model.py#L20), he used same sizes for all 3 of the layers by simply putting `num_layers` to 3.

What do you guys think?