### PR TITLE
Generate speaker embeddings from the mel spectrograms

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
-sudo apt-get update && sudo apt-get install -y libsndfile1
+sudo apt-get update && sudo apt-get install -y libsndfile2
 
 if conda env list | grep -q voice_cloning; then
-    echo voice_cloning environment already exists! 
+    echo voice_cloning environment already exists!
 else
     echo creating new environment
     conda env create -f environment.yml

--- a/tacotron2/model.py
+++ b/tacotron2/model.py
@@ -481,6 +481,7 @@ class Tacotron2(nn.Module):
         output_lengths = to_gpu(output_lengths).long()
 
         return (
+            mel_padded,
             (text_padded, input_lengths, mel_padded, max_len, output_lengths),
             (mel_padded, gate_padded))
 


### PR DESCRIPTION
Not fully tested just yet. This should load the speaker model and run it inline on the mel spectrograms generated from the data loader. This does not incorporate the embedding into the existing tacotron model yet. A saved model path via `torch.save` on the state dict of the embedding model has to be provided when training.

The data loader seems to be doing some additional padding of some kind, not sure if this is compatible with the speaker embedding model just yet.