### PR TITLE
downgrade to python 3.6.8 for compatibility with tacotron2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ out/
 __pycache__/
 
 LibriSpeech/
+LJSpeech-1.1/
 train-clean-100.tar.gz

--- a/environment.yml
+++ b/environment.yml
@@ -23,29 +23,56 @@ dependencies:
   - xz=5.2.5=h7b6447c_0
   - zlib=1.2.12=h7f8727e_2
   - pip:
+    - absl-py==1.0.0
     - appdirs==1.4.4
+    - astor==0.8.1
     - audioread==2.1.9
+    - cached-property==1.5.2
     - cffi==1.15.0
     - charset-normalizer==2.0.12
+    - cycler==0.11.0
+    - dataclasses==0.8
     - decorator==5.1.1
+    - gast==0.2.2
+    - google-pasta==0.2.0
+    - grpcio==1.44.0
+    - h5py==3.1.0
     - idna==3.3
-    - inflect==5.3.0
+    - importlib-metadata==4.8.3
+    - inflect==0.2.5
     - joblib==1.1.0
-    - librosa==0.9.1
+    - keras-applications==1.0.8
+    - keras-preprocessing==1.1.2
+    - librosa==0.6.0
     - llvmlite==0.36.0
+    - markdown==3.3.6
+    - matplotlib==2.1.0
     - numba==0.53.1
     - numpy==1.19.5
+    - opt-einsum==3.3.0
     - packaging==21.3
+    - pillow==8.4.0
     - pooch==1.6.0
+    - protobuf==3.19.4
     - pycparser==2.21
     - pyparsing==3.0.8
+    - python-dateutil==2.8.2
+    - pytz==2022.1
     - requests==2.27.1
     - resampy==0.2.2
     - scikit-learn==0.24.2
-    - scipy==1.5.4
+    - scipy==1.0.0
     - six==1.16.0
     - soundfile==0.10.3.post1
+    - tensorboard==1.15.0
+    - tensorflow==1.15.2
+    - tensorflow-estimator==1.15.1
+    - termcolor==1.1.0
     - threadpoolctl==3.1.0
-    - unidecode==1.3.4
+    - typing-extensions==4.1.1
+    - unidecode==1.0.22
     - urllib3==1.26.9
+    - werkzeug==2.0.3
+    - wrapt==1.14.0
+    - zipp==3.6.0
 prefix: /home/richie/miniconda3/envs/voice_cloning

--- a/environment.yml
+++ b/environment.yml
@@ -4,100 +4,48 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=4.5=1_gnu
-  - ca-certificates=2022.2.1=h06a4308_0
-  - certifi=2021.10.8=py39h06a4308_2
-  - ld_impl_linux-64=2.35.1=h7274673_9
-  - libffi=3.3=he6710b0_2
+  - ca-certificates=2022.3.29=h06a4308_1
+  - certifi=2021.5.30=py36h06a4308_0
+  - libedit=3.1.20210910=h7f8727e_0
+  - libffi=3.2.1=hf484d3e_1007
   - libgcc-ng=9.3.0=h5101ec6_17
   - libgomp=9.3.0=h5101ec6_17
   - libstdcxx-ng=9.3.0=hd4cf53a_17
   - ncurses=6.3=h7f8727e_2
-  - openssl=1.1.1m=h7f8727e_0
-  - pip=21.2.4=py39h06a4308_0
-  - python=3.9.7=h12debd9_1
-  - readline=8.1.2=h7f8727e_1
-  - setuptools=58.0.4=py39h06a4308_0
-  - sqlite=3.37.2=hc218d9a_0
+  - openssl=1.1.1n=h7f8727e_0
+  - pip=21.2.2=py36h06a4308_0
+  - python=3.6.8=h0371630_0
+  - readline=7.0=h7b6447c_5
+  - setuptools=58.0.4=py36h06a4308_0
+  - sqlite=3.33.0=h62c20be_0
   - tk=8.6.11=h1ccaba5_0
-  - tzdata=2021e=hda174b7_0
   - wheel=0.37.1=pyhd3eb1b0_0
   - xz=5.2.5=h7b6447c_0
-  - zlib=1.2.11=h7f8727e_4
+  - zlib=1.2.12=h7f8727e_2
   - pip:
     - appdirs==1.4.4
-    - argon2-cffi==21.3.0
-    - argon2-cffi-bindings==21.2.0
-    - asttokens==2.0.5
-    - attrs==21.4.0
     - audioread==2.1.9
-    - backcall==0.2.0
-    - bleach==4.1.0
     - cffi==1.15.0
     - charset-normalizer==2.0.12
-    - debugpy==1.5.1
     - decorator==5.1.1
-    - defusedxml==0.7.1
-    - entrypoints==0.4
-    - executing==0.8.3
     - idna==3.3
-    - inflect==5.4.0
-    - ipykernel==6.9.1
-    - ipython==8.1.1
-    - ipython-genutils==0.2.0
-    - jedi==0.18.1
-    - jinja2==3.0.3
+    - inflect==5.3.0
     - joblib==1.1.0
-    - jsonschema==4.4.0
-    - jupyter-client==7.1.2
-    - jupyter-core==4.9.2
-    - jupyterlab-pygments==0.1.2
     - librosa==0.9.1
-    - llvmlite==0.38.0
-    - markupsafe==2.1.0
-    - matplotlib-inline==0.1.3
-    - mistune==0.8.4
-    - nbclient==0.5.12
-    - nbconvert==6.4.2
-    - nbformat==5.1.3
-    - nest-asyncio==1.5.4
-    - notebook==6.4.8
-    - numba==0.55.1
-    - numpy==1.21.5
+    - llvmlite==0.36.0
+    - numba==0.53.1
+    - numpy==1.19.5
     - packaging==21.3
-    - pandocfilters==1.5.0
-    - parso==0.8.3
-    - pexpect==4.8.0
-    - pickleshare==0.7.5
-    - pillow==9.0.1
     - pooch==1.6.0
-    - prometheus-client==0.13.1
-    - prompt-toolkit==3.0.28
-    - ptyprocess==0.7.0
-    - pure-eval==0.2.2
     - pycparser==2.21
-    - pygments==2.11.2
-    - pyparsing==3.0.7
-    - pyrsistent==0.18.1
-    - python-dateutil==2.8.2
-    - pyzmq==22.3.0
+    - pyparsing==3.0.8
     - requests==2.27.1
     - resampy==0.2.2
-    - scikit-learn==1.0.2
-    - scipy==1.8.0
-    - send2trash==1.8.0
+    - scikit-learn==0.24.2
+    - scipy==1.5.4
     - six==1.16.0
     - soundfile==0.10.3.post1
-    - stack-data==0.2.0
-    - terminado==0.13.3
-    - testpath==0.6.0
     - threadpoolctl==3.1.0
-    - torch==1.10.2
-    - torchaudio==0.10.2
-    - torchvision==0.11.3
-    - tornado==6.1
-    - traitlets==5.1.1
-    - typing-extensions==4.1.1
-    - unidecode==1.3.3
-    - urllib3==1.26.8
-    - wcwidth==0.2.5
-    - webencodings==0.5.1
+    - unidecode==1.3.4
+    - urllib3==1.26.9
+prefix: /home/richie/miniconda3/envs/voice_cloning

--- a/tacotron2/requirements.txt
+++ b/tacotron2/requirements.txt
@@ -1,8 +1,0 @@
-matplotlib==2.1.0
-tensorflow==1.15.2
-numpy>=1.7.1,<2.0
-inflect==0.2.5
-librosa==0.6.0
-scipy==1.0.0
-Unidecode==1.0.22
-pillow

--- a/tacotron2/requirements.txt
+++ b/tacotron2/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==2.1.0
 tensorflow==1.15.2
-numpy==1.13.3
+numpy>=1.7.1,<2.0
 inflect==0.2.5
 librosa==0.6.0
 scipy==1.0.0


### PR DESCRIPTION
Tacotron2 train script relies on dependencies based on python 3.6.8. As we're currently on 3.9.7, I am downgrading the python version accordingly.

Since the environment.yml includes tacotron2 dependencies, deleteing the file within tacotron2 repo. We'll update the README.md later to make this more clear. I haven't included pytorch since that'd depend on user wanting CUDA / CPU, but we can include the checks in the future to fully automate the setup.

Simply run `. ./setup.sh` like you used to. Tested locally:
![Screenshot from 2022-04-23 22-54-13](https://user-images.githubusercontent.com/43356500/164954129-81b29604-2345-4a95-af65-cc6023681bb3.png)

Afterwards install pytorch using:
`conda install pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch`

Tested locally:
![Screenshot from 2022-04-23 22-55-39](https://user-images.githubusercontent.com/43356500/164954168-627e3d28-5a45-4f7d-aadf-bb1ac999198a.png)
